### PR TITLE
Call execute last, after rescue statement

### DIFF
--- a/lib/activejob_google_cloud_pubsub/adapter.rb
+++ b/lib/activejob_google_cloud_pubsub/adapter.rb
@@ -16,12 +16,11 @@ module ActiveJob
       end
 
       def enqueue(job, attributes = {})
-        promise = Concurrent::Promise.execute(executor: @executor) do
+        Concurrent::Promise.new(executor: @executor) do
           @pubsub.topic_for(job.queue_name).publish JSON.dump(job.serialize), attributes
-        end
-        promise.rescue do |e|
+        end.rescue do |e|
           @logger&.error e
-        end
+        end.execute
       end
 
       def enqueue_at(job, timestamp)


### PR DESCRIPTION
I believe execute should be called last, after the rescue clause. Otherwise the promise could start being executed and fail before rescue is being attached.